### PR TITLE
add:alert-component追加

### DIFF
--- a/apps/front/src/components/atoms/Alert.tsx
+++ b/apps/front/src/components/atoms/Alert.tsx
@@ -4,9 +4,9 @@ interface AlertProps {
     alertType?: 'alert-success' | 'alert-error' | 'alert-warning' | 'alert-info';
     label?: string;
     // daisyUIのbtnプロパティ
-    buttonType?: 'btn-success' | 'btn-error' | 'btn-warning' | 'btn-info';
-    buttonLabel?: string;
-    buttonDisplay?: boolean;
+    btnType?: 'btn-success' | 'btn-error' | 'btn-warning' | 'btn-info';
+    btnLabel?: string;
+    btnDisplay?: boolean;
 };
 
 /**
@@ -23,12 +23,12 @@ interface AlertProps {
 export const Alert: React.FC<AlertProps> = ({
     alertType,
     label,
-    buttonType,
-    buttonLabel,
-    buttonDisplay = false,
+    btnType,
+    btnLabel,
+    btnDisplay = false,
 }) => {
     let btnHide = '';
-    btnHide = buttonDisplay ? 'block' : 'hidden';
+    btnHide = btnDisplay ? 'block' : 'hidden';
 
     return (
         <div role='alert' className={`alert ${alertType}`}>
@@ -45,7 +45,7 @@ export const Alert: React.FC<AlertProps> = ({
             </svg>
             <span>{label}</span>
             <div>
-                <button className={`btn ${buttonType} ${btnHide}`}> {buttonLabel}</button>
+                <button className={`btn ${btnType} ${btnHide}`}> {btnLabel}</button>
             </div>
         </div >
     );

--- a/apps/front/src/components/atoms/Alert.tsx
+++ b/apps/front/src/components/atoms/Alert.tsx
@@ -1,10 +1,10 @@
 import React, { InputHTMLAttributes } from 'react';
 
 interface AlertProps {
-    alertType?: 'success' | 'error' | 'warning' | 'info';
+    alertType?: 'alert-success' | 'alert-error' | 'alert-warning' | 'alert-info';
     label?: string;
     // daisyUIのbtnプロパティ
-    buttonType?: 'success' | 'error' | 'warning' | 'info';
+    buttonType?: 'btn-success' | 'btn-error' | 'btn-warning' | 'btn-info';
     buttonLabel?: string;
     buttonDisplay?: boolean;
 };
@@ -27,15 +27,11 @@ export const Alert: React.FC<AlertProps> = ({
     buttonLabel,
     buttonDisplay = 'false',
 }) => {
-    let varriantAlertClass = '';
-    varriantAlertClass = alertType ? 'alert alert-' + alertType : 'alert alert-success';
-    let varriantButtonClass = '';
-    varriantButtonClass = buttonType ? 'btn btn-' + buttonType : 'btn btn-success';
     let btnHide = '';
     btnHide = buttonDisplay ? 'block' : 'hidden';
 
     return (
-        <div role='alert' className={`${varriantAlertClass}`}>
+        <div role='alert' className={`alert ${alertType}`}>
             <svg
                 xmlns='http://www.w3.org/2000/svg'
                 className='h-6 w-6 shrink-0 stroke-current'
@@ -49,7 +45,7 @@ export const Alert: React.FC<AlertProps> = ({
             </svg>
             <span>{label}</span>
             <div>
-                <button className={`${varriantButtonClass}`}> {buttonLabel}</button>
+                <button className={`btn ${buttonType}`}> {buttonLabel}</button>
             </div>
         </div >
     );

--- a/apps/front/src/components/atoms/Alert.tsx
+++ b/apps/front/src/components/atoms/Alert.tsx
@@ -1,7 +1,7 @@
 import React, { InputHTMLAttributes } from 'react';
 
 interface AlertProps {
-    alertType?: 'alert-success' | 'alert-error' | 'alert-warning' | 'alert-info';
+    alertType?: 'alert' | 'alert-success' | 'alert-error' | 'alert-warning' | 'alert-info';
     label?: string;
     // daisyUIのbtnプロパティ
     btnType?: 'btn-success' | 'btn-error' | 'btn-warning' | 'btn-info';

--- a/apps/front/src/components/atoms/Alert.tsx
+++ b/apps/front/src/components/atoms/Alert.tsx
@@ -25,7 +25,7 @@ export const Alert: React.FC<AlertProps> = ({
     label,
     buttonType,
     buttonLabel,
-    buttonDisplay = 'false',
+    buttonDisplay = false,
 }) => {
     let btnHide = '';
     btnHide = buttonDisplay ? 'block' : 'hidden';
@@ -45,7 +45,7 @@ export const Alert: React.FC<AlertProps> = ({
             </svg>
             <span>{label}</span>
             <div>
-                <button className={`btn ${buttonType}`}> {buttonLabel}</button>
+                <button className={`btn ${buttonType} ${btnHide}`}> {buttonLabel}</button>
             </div>
         </div >
     );

--- a/apps/front/src/components/atoms/Alert.tsx
+++ b/apps/front/src/components/atoms/Alert.tsx
@@ -15,7 +15,7 @@ interface AlertProps {
  * @example
  * export default function Home() {
  *     return (
- *             <Alert  type='error' abel='testText'> 
+ *             <Alert  type='alert-error' label='testText' btnType="btn-success" btnLabel="testButton" btnDisplay={false}> 
  *     );
  * }
  */

--- a/apps/front/src/components/atoms/Alert.tsx
+++ b/apps/front/src/components/atoms/Alert.tsx
@@ -1,0 +1,56 @@
+import React, { InputHTMLAttributes } from 'react';
+
+interface AlertProps {
+    alertType?: 'success' | 'error' | 'warning' | 'info';
+    label?: string;
+    // daisyUIのbtnプロパティ
+    buttonType?: 'success' | 'error' | 'warning' | 'info';
+    buttonLabel?: string;
+    buttonDisplay?: boolean;
+};
+
+/**
+ * daisyUI使用のAlert
+ * 
+ * @example
+ * export default function Home() {
+ *     return (
+ *             <Alert  type='error' abel='testText'> 
+ *     );
+ * }
+ */
+
+export const Alert: React.FC<AlertProps> = ({
+    alertType,
+    label,
+    buttonType,
+    buttonLabel,
+    buttonDisplay = 'false',
+}) => {
+    let varriantAlertClass = '';
+    varriantAlertClass = alertType ? 'alert alert-' + alertType : 'alert alert-success';
+    let varriantButtonClass = '';
+    varriantButtonClass = buttonType ? 'btn btn-' + buttonType : 'btn btn-success';
+    let btnHide = '';
+    btnHide = buttonDisplay ? 'block' : 'hidden';
+
+    return (
+        <div role='alert' className={`${varriantAlertClass}`}>
+            <svg
+                xmlns='http://www.w3.org/2000/svg'
+                className='h-6 w-6 shrink-0 stroke-current'
+                fill='none'
+                viewBox='0 0 24 24'>
+                <path
+                    strokeLinecap='round'
+                    strokeLinejoin='round'
+                    strokeWidth='2'
+                    d='M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z' />
+            </svg>
+            <span>{label}</span>
+            <div>
+                <button className={`${varriantButtonClass}`}> {buttonLabel}</button>
+            </div>
+        </div >
+    );
+}

--- a/apps/front/src/components/atoms/Alert.tsx
+++ b/apps/front/src/components/atoms/Alert.tsx
@@ -7,6 +7,7 @@ interface AlertProps {
     btnType?: 'btn-success' | 'btn-error' | 'btn-warning' | 'btn-info';
     btnLabel?: string;
     btnDisplay?: boolean;
+    onClick?: () => void;
 };
 
 /**
@@ -26,6 +27,7 @@ export const Alert: React.FC<AlertProps> = ({
     btnType,
     btnLabel,
     btnDisplay = false,
+    onClick,
 }) => {
     let btnHide = '';
     btnHide = btnDisplay ? 'block' : 'hidden';
@@ -45,7 +47,7 @@ export const Alert: React.FC<AlertProps> = ({
             </svg>
             <span>{label}</span>
             <div>
-                <button className={`btn ${btnType} ${btnHide}`}> {btnLabel}</button>
+                <button className={`btn ${btnType} ${btnHide}`} onClick={onClick}> {btnLabel}</button>
             </div>
         </div >
     );


### PR DESCRIPTION
# 新しい `Alert` コンポーネントの追加

このプルリクエストでは、新しい `Alert` コンポーネントを `apps/front/src/components/atoms/Alert.tsx` ファイルに追加しました。<br>
このコンポーネントは、daisyUIライブラリを使用してさまざまな種類のアラートを表示するために設計されています。

## 主な変更点

- **`Alert` コンポーネントの作成**  
  `alertType`、`label`、`buttonType`、`buttonLabel`、`buttonDisplay` のプロップを持つコンポーネントを作成し、カスタマイズ可能なアラートメッセージやボタンを提供。

- **デフォルトの `Alert` コンポーネントの実装**  
  オプションでボタンを表示可能なアラートを描画し、daisyUIのスタイルを活用して統一感のあるUIデザインを実現。
